### PR TITLE
add more missing methods from rust and python deque

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "fixed_deque"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed_deque"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2024"
 description = "A fixed size VecDeque to match Python Deque"
 authors = ["Akseli Lukkarila <akseli.lukkarila@nitor.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 #![deny(missing_docs)]
 
 use std::collections::VecDeque;
-use std::ops::{Index, IndexMut};
+use std::collections::vec_deque::Drain;
+use std::ops::{Index, IndexMut, RangeBounds};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -438,6 +439,610 @@ impl<T> Deque<T> {
     pub fn capacity(&self) -> usize {
         self.deque.capacity().min(self.maxlen)
     }
+
+    /// Returns `true` if the deque is full (i.e., `len() == maxlen()`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = Deque::new(3);
+    /// assert!(!deque.is_full());
+    /// deque.push_back(1);
+    /// deque.push_back(2);
+    /// deque.push_back(3);
+    /// assert!(deque.is_full());
+    /// ```
+    #[must_use]
+    pub fn is_full(&self) -> bool {
+        self.deque.len() == self.maxlen
+    }
+
+    /// Returns the remaining capacity before the deque is full.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = Deque::new(5);
+    /// assert_eq!(deque.remaining_capacity(), 5);
+    /// deque.push_back(1);
+    /// deque.push_back(2);
+    /// assert_eq!(deque.remaining_capacity(), 3);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn remaining_capacity(&self) -> usize {
+        self.maxlen.saturating_sub(self.deque.len())
+    }
+
+    /// Swaps elements at indices `i` and `j`.
+    ///
+    /// `i` and `j` may be equal.
+    ///
+    /// Element at index 0 is the front of the queue.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+    /// deque.swap(0, 2);
+    /// assert_eq!(deque.get(0), Some(&3));
+    /// assert_eq!(deque.get(2), Some(&1));
+    /// ```
+    pub fn swap(&mut self, i: usize, j: usize) {
+        self.deque.swap(i, j);
+    }
+
+    /// Shortens the deque, keeping the first `len` elements and dropping the rest.
+    ///
+    /// If `len` is greater than or equal to the deque's current length, this has no effect.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+    /// deque.truncate(2);
+    /// assert_eq!(deque.len(), 2);
+    /// assert_eq!(deque.get(0), Some(&1));
+    /// assert_eq!(deque.get(1), Some(&2));
+    /// ```
+    pub fn truncate(&mut self, len: usize) {
+        self.deque.truncate(len);
+    }
+
+    /// Removes and returns the element at `index` from the deque.
+    /// Whichever end is closer to the removal point will be moved to make
+    /// room, and all the affected elements will be moved to new positions.
+    /// Returns `None` if `index` is out of bounds.
+    ///
+    /// Element at index 0 is the front of the queue.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+    /// assert_eq!(deque.remove(1), Some(2));
+    /// assert_eq!(deque.len(), 2);
+    /// assert_eq!(deque.get(0), Some(&1));
+    /// assert_eq!(deque.get(1), Some(&3));
+    /// ```
+    pub fn remove(&mut self, index: usize) -> Option<T> {
+        self.deque.remove(index)
+    }
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all elements `e` for which `f(&e)` returns `false`.
+    /// This method operates in place, visiting each element exactly once in the
+    /// original order, and preserves the order of the retained elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+    /// deque.retain(|&x| x % 2 == 0);
+    /// assert_eq!(deque.len(), 2);
+    /// assert_eq!(deque.get(0), Some(&2));
+    /// assert_eq!(deque.get(1), Some(&4));
+    /// ```
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&T) -> bool,
+    {
+        self.deque.retain(f);
+    }
+
+    /// Retains only the elements specified by the predicate, passing a mutable reference.
+    ///
+    /// In other words, remove all elements `e` for which `f(&mut e)` returns `false`.
+    /// This method operates in place, visiting each element exactly once in the
+    /// original order, and preserves the order of the retained elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+    /// deque.retain_mut(|x| {
+    ///     if *x % 2 == 0 {
+    ///         *x *= 10;
+    ///         true
+    ///     } else {
+    ///         false
+    ///     }
+    /// });
+    /// assert_eq!(deque.len(), 2);
+    /// assert_eq!(deque.get(0), Some(&20));
+    /// assert_eq!(deque.get(1), Some(&40));
+    /// ```
+    pub fn retain_mut<F>(&mut self, f: F)
+    where
+        F: FnMut(&mut T) -> bool,
+    {
+        self.deque.retain_mut(f);
+    }
+
+    /// Creates a draining iterator that removes the specified range in the deque
+    /// and yields the removed items.
+    ///
+    /// When the iterator is dropped, all elements in the range are removed
+    /// from the deque, even if the iterator was not fully consumed. If the
+    /// iterator is not dropped (with `mem::forget` for example), the deque
+    /// may have lost and leaked elements.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the starting point is greater than the end point or if
+    /// the end point is greater than the length of the deque.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+    /// let drained: Vec<i32> = deque.drain(1..4).collect();
+    /// assert_eq!(drained, vec![2, 3, 4]);
+    /// assert_eq!(deque.len(), 2);
+    /// assert_eq!(deque.get(0), Some(&1));
+    /// assert_eq!(deque.get(1), Some(&5));
+    /// ```
+    pub fn drain<R>(&mut self, range: R) -> Drain<'_, T>
+    where
+        R: RangeBounds<usize>,
+    {
+        self.deque.drain(range)
+    }
+
+    /// Rotates the deque `n` places to the left.
+    ///
+    /// Equivalently, this rotates the front of the deque towards the back.
+    ///
+    /// # Panics
+    ///
+    /// If `n` is greater than `len()`. To avoid panic, call with `n % len()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+    /// deque.rotate_left(2);
+    /// assert_eq!(deque.get(0), Some(&3));
+    /// assert_eq!(deque.get(4), Some(&2));
+    /// ```
+    pub fn rotate_left(&mut self, n: usize) {
+        self.deque.rotate_left(n);
+    }
+
+    /// Rotates the deque `n` places to the right.
+    ///
+    /// Equivalently, this rotates the back of the deque towards the front.
+    ///
+    /// # Panics
+    ///
+    /// If `n` is greater than `len()`. To avoid panic, call with `n % len()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+    /// deque.rotate_right(2);
+    /// assert_eq!(deque.get(0), Some(&4));
+    /// assert_eq!(deque.get(4), Some(&3));
+    /// ```
+    pub fn rotate_right(&mut self, n: usize) {
+        self.deque.rotate_right(n);
+    }
+
+    /// Returns a pair of slices which contain, in order, the contents of the deque.
+    ///
+    /// If `make_contiguous` was previously called,
+    /// all elements will be in the first slice and the second slice will be empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = Deque::new(5);
+    /// deque.push_back(1);
+    /// deque.push_back(2);
+    /// deque.push_back(3);
+    /// let (front, back) = deque.as_slices();
+    /// // The slices together contain all elements
+    /// assert_eq!(front.len() + back.len(), 3);
+    /// ```
+    #[must_use]
+    pub fn as_slices(&self) -> (&[T], &[T]) {
+        self.deque.as_slices()
+    }
+
+    /// Returns a pair of mutable slices which contain, in order, the contents of the deque.
+    ///
+    /// If `make_contiguous` was previously called,
+    /// all elements will be in the first slice and the second slice will be empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+    /// let (front, back) = deque.as_mut_slices();
+    /// if let Some(first) = front.first_mut() {
+    ///     *first = 10;
+    /// }
+    /// assert_eq!(deque.get(0), Some(&10));
+    /// ```
+    #[must_use]
+    pub fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
+        self.deque.as_mut_slices()
+    }
+
+    /// Rearranges the internal storage of this deque so it is one contiguous slice,
+    /// which is then returned.
+    ///
+    /// This method does not allocate and does not change the order of the elements.
+    /// After calling this method, `as_slices` will return a single contiguous slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = Deque::new(5);
+    /// deque.push_back(2);
+    /// deque.push_back(1);
+    /// deque.push_front(3);
+    ///
+    /// // The deque may be split across the ring buffer
+    /// let slice = deque.make_contiguous();
+    /// assert_eq!(slice, &[3, 2, 1]);
+    ///
+    /// // Now as_slices returns a single slice
+    /// let (front, back) = deque.as_slices();
+    /// assert_eq!(front, &[3, 2, 1]);
+    /// assert!(back.is_empty());
+    /// ```
+    pub fn make_contiguous(&mut self) -> &mut [T] {
+        self.deque.make_contiguous()
+    }
+
+    /// Binary searches the sorted deque for a given element.
+    ///
+    /// If the value is found then `Result::Ok` is returned,
+    /// containing the index of the matching element.
+    /// If there are multiple matches, then any one of the matches could be returned.
+    ///
+    /// If the value is not found then `Result::Err` is returned,
+    /// containing the index where a matching element could be inserted while maintaining sorted order.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(index)` if the value is not found, where `index` is the
+    /// position where the value could be inserted to maintain sorted order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+    /// assert_eq!(deque.binary_search(&3), Ok(2));
+    /// assert_eq!(deque.binary_search(&6), Err(5));
+    /// assert_eq!(deque.binary_search(&0), Err(0));
+    /// ```
+    pub fn binary_search(&self, x: &T) -> Result<usize, usize>
+    where
+        T: Ord,
+    {
+        self.deque.binary_search(x)
+    }
+
+    /// Binary searches the sorted deque with a comparator function.
+    ///
+    /// The comparator function should return an ordering for the partitioning
+    /// of the deque. For a given element, the comparator function should return:
+    /// - `Ordering::Less` if the element should come before the target
+    /// - `Ordering::Equal` if the element matches the target
+    /// - `Ordering::Greater` if the element should come after the target
+    ///
+    /// If the value is found then `Result::Ok` is returned,
+    /// containing the index of the matching element.
+    /// If there are multiple matches, then any one of the matches could be returned.
+    ///
+    /// If the value is not found then `Result::Err` is returned,
+    /// containing the index where a matching element could be inserted while maintaining sorted order.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(index)` if the value is not found, where `index` is the
+    /// position where the value could be inserted to maintain sorted order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+    /// assert_eq!(deque.binary_search_by(|x| x.cmp(&3)), Ok(2));
+    /// assert_eq!(deque.binary_search_by(|x| x.cmp(&6)), Err(5));
+    /// ```
+    pub fn binary_search_by<F>(&self, f: F) -> Result<usize, usize>
+    where
+        F: FnMut(&T) -> std::cmp::Ordering,
+    {
+        self.deque.binary_search_by(f)
+    }
+
+    /// Binary searches the sorted deque with a key extraction function.
+    ///
+    /// Assumes that the deque is sorted by the key.
+    ///
+    /// If the value is found then `Result::Ok` is returned,
+    /// containing the index of the matching element.
+    /// If there are multiple matches, then any one of the matches could be returned.
+    ///
+    /// If the value is not found then `Result::Err` is returned,
+    /// containing the index where a matching element could be inserted while maintaining sorted order.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(index)` if the value is not found, where `index` is the
+    /// position where the value could be inserted to maintain sorted order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let deque: Deque<(i32, &str)> = (vec![(1, "a"), (2, "b"), (3, "c")], 10).into();
+    /// assert_eq!(deque.binary_search_by_key(&2, |&(k, _)| k), Ok(1));
+    /// assert_eq!(deque.binary_search_by_key(&4, |&(k, _)| k), Err(3));
+    /// ```
+    pub fn binary_search_by_key<B, F>(&self, b: &B, f: F) -> Result<usize, usize>
+    where
+        F: FnMut(&T) -> B,
+        B: Ord,
+    {
+        self.deque.binary_search_by_key(b, f)
+    }
+
+    /// Counts the number of elements equal to the given value.
+    ///
+    /// This is equivalent to Python's `deque.count(x)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let deque: Deque<i32> = (vec![1, 2, 2, 3, 2, 4], 10).into();
+    /// assert_eq!(deque.count(&2), 3);
+    /// assert_eq!(deque.count(&5), 0);
+    /// ```
+    pub fn count(&self, value: &T) -> usize
+    where
+        T: PartialEq,
+    {
+        self.deque.iter().filter(|&x| x == value).count()
+    }
+
+    /// Returns the index of the first element equal to the given value,
+    /// or `None` if not found.
+    ///
+    /// This is similar to Python's `deque.index(x)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let deque: Deque<i32> = (vec![1, 2, 3, 2, 4], 10).into();
+    /// assert_eq!(deque.index(&2), Some(1));
+    /// assert_eq!(deque.index(&5), None);
+    /// ```
+    pub fn index(&self, value: &T) -> Option<usize>
+    where
+        T: PartialEq,
+    {
+        self.deque.iter().position(|x| x == value)
+    }
+
+    /// Returns the index of the first element equal to the given value
+    /// within the range `[start, end)`, or `None` if not found.
+    ///
+    /// This is similar to Python's `deque.index(x, start, stop)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let deque: Deque<i32> = (vec![1, 2, 3, 2, 4], 10).into();
+    /// assert_eq!(deque.index_range(&2, 0, 5), Some(1));
+    /// assert_eq!(deque.index_range(&2, 2, 5), Some(3));
+    /// assert_eq!(deque.index_range(&2, 4, 5), None);
+    /// ```
+    pub fn index_range(&self, value: &T, start: usize, end: usize) -> Option<usize>
+    where
+        T: PartialEq,
+    {
+        let end = end.min(self.deque.len());
+        if start >= end {
+            return None;
+        }
+        self.deque
+            .iter()
+            .skip(start)
+            .take(end - start)
+            .position(|x| x == value)
+            .map(|pos| pos + start)
+    }
+
+    /// Extends the front of the deque with the contents of an iterator.
+    ///
+    /// Elements are prepended one at a time,
+    /// so the final order is reversed relative to the iterator (matching Python's `deque.extendleft()` behavior).
+    ///
+    /// If the deque would exceed `maxlen`, elements are removed from the back.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = (vec![4, 5], 5).into();
+    /// deque.extend_front([1, 2, 3]);
+    /// // Elements are prepended in reverse order: 3, 2, 1, then 4, 5
+    /// assert_eq!(deque.get(0), Some(&3));
+    /// assert_eq!(deque.get(1), Some(&2));
+    /// assert_eq!(deque.get(2), Some(&1));
+    /// assert_eq!(deque.get(3), Some(&4));
+    /// assert_eq!(deque.get(4), Some(&5));
+    /// ```
+    pub fn extend_front<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
+        for item in iter {
+            self.push_front(item);
+        }
+    }
+
+    /// Reverses the order of elements in the deque in-place.
+    ///
+    /// This is equivalent to Python's `deque.reverse()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+    /// deque.reverse();
+    /// assert_eq!(deque.get(0), Some(&5));
+    /// assert_eq!(deque.get(4), Some(&1));
+    /// ```
+    pub fn reverse(&mut self) {
+        let slice = self.deque.make_contiguous();
+        slice.reverse();
+    }
+
+    /// Removes the first occurrence of a value from the deque.
+    ///
+    /// Returns the removed value if found, `None` otherwise.
+    ///
+    /// This is similar to Python's `deque.remove(value)`,
+    /// but returns an Option instead of raising an exception when the value is not found.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = (vec![1, 2, 3, 2, 4], 10).into();
+    /// assert_eq!(deque.remove_first(&2), Some(2));
+    /// assert_eq!(deque.len(), 4);
+    /// assert_eq!(deque.get(0), Some(&1));
+    /// assert_eq!(deque.get(1), Some(&3)); // First 2 was removed
+    /// assert_eq!(deque.get(2), Some(&2)); // Second 2 is still there
+    ///
+    /// assert_eq!(deque.remove_first(&5), None); // Returns None if not found
+    /// ```
+    pub fn remove_first(&mut self, value: &T) -> Option<T>
+    where
+        T: PartialEq,
+    {
+        if let Some(pos) = self.index(value) {
+            self.deque.remove(pos)
+        } else {
+            None
+        }
+    }
+
+    /// Inserts an element at the given index, shifting all elements after it to the right.
+    ///
+    /// If the deque is full, the last (back) element is dropped to make room for the
+    /// new element, and the dropped element is returned. Otherwise, `None` is returned.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// let mut deque: Deque<i32> = (vec![1, 3, 4], 5).into();
+    /// assert_eq!(deque.insert(1, 2), None);
+    /// assert_eq!(deque.get(0), Some(&1));
+    /// assert_eq!(deque.get(1), Some(&2));
+    /// assert_eq!(deque.get(2), Some(&3));
+    /// assert_eq!(deque.get(3), Some(&4));
+    /// ```
+    ///
+    /// ```
+    /// use fixed_deque::Deque;
+    ///
+    /// // When full, the last element is dropped
+    /// let mut deque: Deque<i32> = (vec![1, 2, 3], 3).into();
+    /// let dropped = deque.insert(1, 10);
+    /// assert_eq!(dropped, Some(3)); // 3 was at the back and got dropped
+    /// assert_eq!(deque.iter().copied().collect::<Vec<_>>(), vec![1, 10, 2]);
+    /// ```
+    pub fn insert(&mut self, index: usize, value: T) -> Option<T> {
+        if self.deque.len() == self.maxlen {
+            // If at max capacity, pop the back element before inserting
+            let popped = self.deque.pop_back();
+            self.deque.insert(index, value);
+            popped
+        } else {
+            self.deque.insert(index, value);
+            None
+        }
+    }
 }
 
 // Implement From for single value.
@@ -636,13 +1241,12 @@ impl<T> Extend<T> for Deque<T> {
         I: IntoIterator<Item = T>,
     {
         let iter = iter.into_iter();
-        let remaining_space = self.maxlen.saturating_sub(self.deque.len());
 
         // If we know the iterator fits, use direct extend
         if iter
             .size_hint()
             .1
-            .is_some_and(|upper| upper <= remaining_space)
+            .is_some_and(|upper| upper <= self.remaining_capacity())
         {
             self.deque.extend(iter);
         } else {
@@ -682,13 +1286,12 @@ where
         I: IntoIterator<Item = &'a T>,
     {
         let iter = iter.into_iter();
-        let remaining_space = self.maxlen.saturating_sub(self.deque.len());
 
         // If we know the iterator fits, use direct extend
         if iter
             .size_hint()
             .1
-            .is_some_and(|upper| upper <= remaining_space)
+            .is_some_and(|upper| upper <= self.remaining_capacity())
         {
             self.deque.extend(iter);
         } else {
@@ -697,28 +1300,6 @@ where
                 self.push_back(item);
             }
         }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<T: Serialize> Serialize for Deque<T> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.deque.serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for Deque<T> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let deque = VecDeque::deserialize(deserializer)?;
-        let maxlen = deque.len();
-        Ok(Self { deque, maxlen })
     }
 }
 
@@ -788,6 +1369,39 @@ mod initialization_tests {
         assert_eq!(deque.maxlen(), 8);
         assert_eq!(deque.front(), Some(&1));
         assert_eq!(deque.back(), Some(&8));
+    }
+
+    #[test]
+    fn test_from_vec_truncation_keeps_first_elements() {
+        let deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 3).into();
+        assert_eq!(deque.len(), 3);
+        assert_eq!(deque.get(0), Some(&1));
+        assert_eq!(deque.get(1), Some(&2));
+        assert_eq!(deque.get(2), Some(&3));
+    }
+
+    #[test]
+    fn test_from_vec_deque_truncation_keeps_first_elements() {
+        let vec_deque = VecDeque::from(vec![10, 20, 30, 40, 50]);
+        let deque: Deque<i32> = (vec_deque, 3).into();
+        assert_eq!(deque.len(), 3);
+        assert_eq!(deque.get(0), Some(&10));
+        assert_eq!(deque.get(1), Some(&20));
+        assert_eq!(deque.get(2), Some(&30));
+    }
+
+    #[test]
+    fn test_from_vec_smaller_than_maxlen() {
+        let deque: Deque<i32> = (vec![1, 2], 10).into();
+        assert_eq!(deque.len(), 2);
+        assert_eq!(deque.maxlen(), 10);
+    }
+
+    #[test]
+    fn test_from_empty_vec() {
+        let deque: Deque<i32> = (vec![], 5).into();
+        assert_eq!(deque.len(), 0);
+        assert_eq!(deque.maxlen(), 5);
     }
 }
 
@@ -1399,6 +2013,1104 @@ mod extend_tests {
     }
 }
 
+#[cfg(test)]
+mod is_full_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_is_full_empty_deque() {
+        let deque: Deque<i32> = Deque::new(3);
+        assert!(!deque.is_full());
+    }
+
+    #[test]
+    fn test_is_full_partially_filled() {
+        let mut deque: Deque<i32> = Deque::new(5);
+        deque.push_back(1);
+        deque.push_back(2);
+        assert!(!deque.is_full());
+    }
+
+    #[test]
+    fn test_is_full_exactly_full() {
+        let mut deque: Deque<i32> = Deque::new(3);
+        deque.push_back(1);
+        deque.push_back(2);
+        deque.push_back(3);
+        assert!(deque.is_full());
+    }
+
+    #[test]
+    fn test_is_full_after_overflow() {
+        let mut deque: Deque<i32> = Deque::new(2);
+        deque.push_back(1);
+        deque.push_back(2);
+        deque.push_back(3); // Overflow
+        assert!(deque.is_full());
+    }
+
+    #[test]
+    fn test_is_full_after_pop() {
+        let mut deque: Deque<i32> = Deque::new(2);
+        deque.push_back(1);
+        deque.push_back(2);
+        assert!(deque.is_full());
+        deque.pop_front();
+        assert!(!deque.is_full());
+    }
+}
+
+#[cfg(test)]
+mod remaining_capacity_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_remaining_capacity_empty() {
+        let deque: Deque<i32> = Deque::new(5);
+        assert_eq!(deque.remaining_capacity(), 5);
+    }
+
+    #[test]
+    fn test_remaining_capacity_partially_filled() {
+        let mut deque: Deque<i32> = Deque::new(10);
+        deque.push_back(1);
+        deque.push_back(2);
+        deque.push_back(3);
+        assert_eq!(deque.remaining_capacity(), 7);
+    }
+
+    #[test]
+    fn test_remaining_capacity_full() {
+        let mut deque: Deque<i32> = Deque::new(3);
+        deque.push_back(1);
+        deque.push_back(2);
+        deque.push_back(3);
+        assert_eq!(deque.remaining_capacity(), 0);
+    }
+}
+
+#[cfg(test)]
+mod swap_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_swap_basic() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        deque.swap(0, 4);
+        assert_eq!(deque.get(0), Some(&5));
+        assert_eq!(deque.get(4), Some(&1));
+        // Middle elements unchanged
+        assert_eq!(deque.get(1), Some(&2));
+        assert_eq!(deque.get(2), Some(&3));
+        assert_eq!(deque.get(3), Some(&4));
+    }
+
+    #[test]
+    fn test_swap_adjacent() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.swap(0, 1);
+        assert_eq!(deque.get(0), Some(&2));
+        assert_eq!(deque.get(1), Some(&1));
+        assert_eq!(deque.get(2), Some(&3));
+    }
+
+    #[test]
+    fn test_swap_same_index() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.swap(1, 1);
+        assert_eq!(deque.get(0), Some(&1));
+        assert_eq!(deque.get(1), Some(&2));
+        assert_eq!(deque.get(2), Some(&3));
+    }
+
+    #[test]
+    fn test_swap_two_elements() {
+        let mut deque: Deque<char> = (vec!['a', 'b'], 5).into();
+        deque.swap(0, 1);
+        assert_eq!(deque.get(0), Some(&'b'));
+        assert_eq!(deque.get(1), Some(&'a'));
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed")]
+    fn test_swap_out_of_bounds() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.swap(0, 10);
+    }
+}
+
+#[cfg(test)]
+mod truncate_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_truncate_basic() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        deque.truncate(3);
+        assert_eq!(deque.len(), 3);
+        assert_eq!(deque.get(0), Some(&1));
+        assert_eq!(deque.get(1), Some(&2));
+        assert_eq!(deque.get(2), Some(&3));
+    }
+
+    #[test]
+    fn test_truncate_to_zero() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.truncate(0);
+        assert!(deque.is_empty());
+        assert_eq!(deque.len(), 0);
+    }
+
+    #[test]
+    fn test_truncate_larger_than_len() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 10).into();
+        deque.truncate(100);
+        assert_eq!(deque.len(), 3);
+        assert_eq!(deque.get(0), Some(&1));
+    }
+
+    #[test]
+    fn test_truncate_equal_to_len() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.truncate(3);
+        assert_eq!(deque.len(), 3);
+    }
+
+    #[test]
+    fn test_truncate_empty_deque() {
+        let mut deque: Deque<i32> = Deque::new(5);
+        deque.truncate(2);
+        assert!(deque.is_empty());
+    }
+
+    #[test]
+    fn test_truncate_to_one() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        deque.truncate(1);
+        assert_eq!(deque.len(), 1);
+        assert_eq!(deque.front(), Some(&1));
+        assert_eq!(deque.back(), Some(&1));
+    }
+}
+
+#[cfg(test)]
+mod remove_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_remove_middle() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        let removed = deque.remove(2);
+        assert_eq!(removed, Some(3));
+        assert_eq!(deque.len(), 4);
+        assert_eq!(deque.get(0), Some(&1));
+        assert_eq!(deque.get(1), Some(&2));
+        assert_eq!(deque.get(2), Some(&4));
+        assert_eq!(deque.get(3), Some(&5));
+    }
+
+    #[test]
+    fn test_remove_front() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        let removed = deque.remove(0);
+        assert_eq!(removed, Some(1));
+        assert_eq!(deque.len(), 2);
+        assert_eq!(deque.front(), Some(&2));
+    }
+
+    #[test]
+    fn test_remove_back() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        let removed = deque.remove(2);
+        assert_eq!(removed, Some(3));
+        assert_eq!(deque.len(), 2);
+        assert_eq!(deque.back(), Some(&2));
+    }
+
+    #[test]
+    fn test_remove_out_of_bounds() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        let removed = deque.remove(10);
+        assert_eq!(removed, None);
+        assert_eq!(deque.len(), 3);
+    }
+
+    #[test]
+    fn test_remove_only_element() {
+        let mut deque: Deque<i32> = (vec![42], 5).into();
+        let removed = deque.remove(0);
+        assert_eq!(removed, Some(42));
+        assert!(deque.is_empty());
+    }
+
+    #[test]
+    fn test_remove_from_empty() {
+        let mut deque: Deque<i32> = Deque::new(5);
+        let removed = deque.remove(0);
+        assert_eq!(removed, None);
+    }
+}
+
+#[cfg(test)]
+mod retain_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_retain_even_numbers() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5, 6], 10).into();
+        deque.retain(|&x| x % 2 == 0);
+        assert_eq!(deque.len(), 3);
+        assert_eq!(deque.get(0), Some(&2));
+        assert_eq!(deque.get(1), Some(&4));
+        assert_eq!(deque.get(2), Some(&6));
+    }
+
+    #[test]
+    fn test_retain_all() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.retain(|_| true);
+        assert_eq!(deque.len(), 3);
+    }
+
+    #[test]
+    fn test_retain_none() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.retain(|_| false);
+        assert!(deque.is_empty());
+    }
+
+    #[test]
+    fn test_retain_empty_deque() {
+        let mut deque: Deque<i32> = Deque::new(5);
+        deque.retain(|&x| x > 0);
+        assert!(deque.is_empty());
+    }
+
+    #[test]
+    fn test_retain_strings() {
+        let mut deque: Deque<String> = (
+            vec!["hello".to_string(), "world".to_string(), "hi".to_string()],
+            5,
+        )
+            .into();
+        deque.retain(|s| s.len() > 2);
+        assert_eq!(deque.len(), 2);
+        assert_eq!(deque.get(0), Some(&"hello".to_string()));
+        assert_eq!(deque.get(1), Some(&"world".to_string()));
+    }
+}
+
+#[cfg(test)]
+mod retain_mut_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_retain_mut_filter_and_modify() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        deque.retain_mut(|x| {
+            if *x % 2 == 0 {
+                *x *= 10;
+                true
+            } else {
+                false
+            }
+        });
+        assert_eq!(deque.len(), 2);
+        assert_eq!(deque.get(0), Some(&20));
+        assert_eq!(deque.get(1), Some(&40));
+    }
+
+    #[test]
+    fn test_retain_mut_modify_all() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.retain_mut(|x| {
+            *x += 100;
+            true
+        });
+        assert_eq!(deque.len(), 3);
+        assert_eq!(deque.get(0), Some(&101));
+        assert_eq!(deque.get(1), Some(&102));
+        assert_eq!(deque.get(2), Some(&103));
+    }
+
+    #[test]
+    fn test_retain_mut_remove_all() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.retain_mut(|_| false);
+        assert!(deque.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod drain_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_drain_middle() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        let drained: Vec<i32> = deque.drain(1..4).collect();
+        assert_eq!(drained, vec![2, 3, 4]);
+        assert_eq!(deque.len(), 2);
+        assert_eq!(deque.get(0), Some(&1));
+        assert_eq!(deque.get(1), Some(&5));
+    }
+
+    #[test]
+    fn test_drain_all() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        let drained: Vec<i32> = deque.drain(..).collect();
+        assert_eq!(drained, vec![1, 2, 3]);
+        assert!(deque.is_empty());
+    }
+
+    #[test]
+    fn test_drain_front() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        let drained: Vec<i32> = deque.drain(..2).collect();
+        assert_eq!(drained, vec![1, 2]);
+        assert_eq!(deque.len(), 3);
+        assert_eq!(deque.front(), Some(&3));
+    }
+
+    #[test]
+    fn test_drain_back() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        let drained: Vec<i32> = deque.drain(3..).collect();
+        assert_eq!(drained, vec![4, 5]);
+        assert_eq!(deque.len(), 3);
+        assert_eq!(deque.back(), Some(&3));
+    }
+
+    #[test]
+    fn test_drain_empty_range() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        assert!(deque.drain(1..1).next().is_none());
+        assert_eq!(deque.len(), 3);
+    }
+
+    #[test]
+    fn test_drain_inclusive_range() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        let drained: Vec<i32> = deque.drain(1..=3).collect();
+        assert_eq!(drained, vec![2, 3, 4]);
+        assert_eq!(deque.len(), 2);
+    }
+}
+
+#[cfg(test)]
+mod rotate_left_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_rotate_left_basic() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        deque.rotate_left(2);
+        assert_eq!(deque.get(0), Some(&3));
+        assert_eq!(deque.get(1), Some(&4));
+        assert_eq!(deque.get(2), Some(&5));
+        assert_eq!(deque.get(3), Some(&1));
+        assert_eq!(deque.get(4), Some(&2));
+    }
+
+    #[test]
+    fn test_rotate_left_zero() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.rotate_left(0);
+        assert_eq!(deque.get(0), Some(&1));
+        assert_eq!(deque.get(1), Some(&2));
+        assert_eq!(deque.get(2), Some(&3));
+    }
+
+    #[test]
+    fn test_rotate_left_full_rotation() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.rotate_left(3);
+        assert_eq!(deque.get(0), Some(&1));
+        assert_eq!(deque.get(1), Some(&2));
+        assert_eq!(deque.get(2), Some(&3));
+    }
+
+    #[test]
+    fn test_rotate_left_one() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4], 10).into();
+        deque.rotate_left(1);
+        assert_eq!(deque.get(0), Some(&2));
+        assert_eq!(deque.get(3), Some(&1));
+    }
+}
+
+#[cfg(test)]
+mod rotate_right_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_rotate_right_basic() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        deque.rotate_right(2);
+        assert_eq!(deque.get(0), Some(&4));
+        assert_eq!(deque.get(1), Some(&5));
+        assert_eq!(deque.get(2), Some(&1));
+        assert_eq!(deque.get(3), Some(&2));
+        assert_eq!(deque.get(4), Some(&3));
+    }
+
+    #[test]
+    fn test_rotate_right_zero() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.rotate_right(0);
+        assert_eq!(deque.get(0), Some(&1));
+        assert_eq!(deque.get(1), Some(&2));
+        assert_eq!(deque.get(2), Some(&3));
+    }
+
+    #[test]
+    fn test_rotate_right_full_rotation() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.rotate_right(3);
+        assert_eq!(deque.get(0), Some(&1));
+        assert_eq!(deque.get(1), Some(&2));
+        assert_eq!(deque.get(2), Some(&3));
+    }
+
+    #[test]
+    fn test_rotate_left_and_right_inverse() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        deque.rotate_left(2);
+        deque.rotate_right(2);
+        assert_eq!(deque.get(0), Some(&1));
+        assert_eq!(deque.get(4), Some(&5));
+    }
+}
+
+#[cfg(test)]
+mod as_slices_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_as_slices_basic() {
+        let mut deque: Deque<i32> = Deque::new(5);
+        deque.push_back(1);
+        deque.push_back(2);
+        deque.push_back(3);
+        let (front, back) = deque.as_slices();
+        assert_eq!(front.len() + back.len(), 3);
+    }
+
+    #[test]
+    fn test_as_slices_empty() {
+        let deque: Deque<i32> = Deque::new(5);
+        let (front, back) = deque.as_slices();
+        assert!(front.is_empty());
+        assert!(back.is_empty());
+    }
+
+    #[test]
+    fn test_as_slices_after_push_front() {
+        let mut deque: Deque<i32> = Deque::new(5);
+        deque.push_back(2);
+        deque.push_back(3);
+        deque.push_front(1);
+        let (front, back) = deque.as_slices();
+        // Together they should contain all elements
+        let mut all: Vec<i32> = front.to_vec();
+        all.extend_from_slice(back);
+        assert_eq!(all, vec![1, 2, 3]);
+    }
+}
+
+#[cfg(test)]
+mod as_mut_slices_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_as_mut_slices_modify() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        let (front, _back) = deque.as_mut_slices();
+        if let Some(first) = front.first_mut() {
+            *first = 100;
+        }
+        assert_eq!(deque.get(0), Some(&100));
+    }
+
+    #[test]
+    fn test_as_mut_slices_modify_all() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        {
+            let (front, back) = deque.as_mut_slices();
+            for x in front.iter_mut() {
+                *x *= 2;
+            }
+            for x in back.iter_mut() {
+                *x *= 2;
+            }
+        }
+        // All elements should be doubled
+        let sum: i32 = deque.iter().sum();
+        assert_eq!(sum, 12); // (1+2+3)*2 = 12
+    }
+}
+
+#[cfg(test)]
+mod make_contiguous_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_make_contiguous_basic() {
+        let mut deque: Deque<i32> = Deque::new(5);
+        deque.push_back(2);
+        deque.push_back(3);
+        deque.push_front(1);
+
+        let slice = deque.make_contiguous();
+        assert_eq!(slice, &[1, 2, 3]);
+    }
+
+    #[test]
+    fn test_make_contiguous_already_contiguous() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        let slice = deque.make_contiguous();
+        assert_eq!(slice, &[1, 2, 3]);
+    }
+
+    #[test]
+    fn test_make_contiguous_empty() {
+        let mut deque: Deque<i32> = Deque::new(5);
+        let slice = deque.make_contiguous();
+        assert!(slice.is_empty());
+    }
+
+    #[test]
+    fn test_make_contiguous_then_as_slices() {
+        let mut deque: Deque<i32> = Deque::new(5);
+        deque.push_back(2);
+        deque.push_front(1);
+        deque.push_back(3);
+
+        deque.make_contiguous();
+        let (front, back) = deque.as_slices();
+        assert_eq!(front, &[1, 2, 3]);
+        assert!(back.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod binary_search_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_binary_search_found() {
+        let deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        assert_eq!(deque.binary_search(&3), Ok(2));
+        assert_eq!(deque.binary_search(&1), Ok(0));
+        assert_eq!(deque.binary_search(&5), Ok(4));
+    }
+
+    #[test]
+    fn test_binary_search_not_found() {
+        let deque: Deque<i32> = (vec![1, 2, 4, 5], 10).into();
+        assert_eq!(deque.binary_search(&3), Err(2));
+        assert_eq!(deque.binary_search(&0), Err(0));
+        assert_eq!(deque.binary_search(&6), Err(4));
+    }
+
+    #[test]
+    fn test_binary_search_empty() {
+        let deque: Deque<i32> = Deque::new(5);
+        assert_eq!(deque.binary_search(&1), Err(0));
+    }
+
+    #[test]
+    fn test_binary_search_single_element() {
+        let deque: Deque<i32> = (vec![5], 10).into();
+        assert_eq!(deque.binary_search(&5), Ok(0));
+        assert_eq!(deque.binary_search(&3), Err(0));
+        assert_eq!(deque.binary_search(&7), Err(1));
+    }
+}
+
+#[cfg(test)]
+mod binary_search_by_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_binary_search_by_found() {
+        let deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        assert_eq!(deque.binary_search_by(|x| x.cmp(&3)), Ok(2));
+    }
+
+    #[test]
+    fn test_binary_search_by_not_found() {
+        let deque: Deque<i32> = (vec![1, 2, 4, 5], 10).into();
+        assert_eq!(deque.binary_search_by(|x| x.cmp(&3)), Err(2));
+    }
+
+    #[test]
+    fn test_binary_search_by_custom_comparator() {
+        // Search in reverse-sorted deque
+        let deque: Deque<i32> = (vec![5, 4, 3, 2, 1], 10).into();
+        // Reverse comparison
+        assert_eq!(deque.binary_search_by(|x| 3.cmp(x)), Ok(2));
+    }
+}
+
+#[cfg(test)]
+mod binary_search_by_key_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_binary_search_by_key_found() {
+        let deque: Deque<(i32, &str)> = (vec![(1, "a"), (2, "b"), (3, "c"), (4, "d")], 10).into();
+        assert_eq!(deque.binary_search_by_key(&2, |&(k, _)| k), Ok(1));
+        assert_eq!(deque.binary_search_by_key(&4, |&(k, _)| k), Ok(3));
+    }
+
+    #[test]
+    fn test_binary_search_by_key_not_found() {
+        let deque: Deque<(i32, &str)> = (vec![(1, "a"), (3, "c"), (5, "e")], 10).into();
+        assert_eq!(deque.binary_search_by_key(&2, |&(k, _)| k), Err(1));
+        assert_eq!(deque.binary_search_by_key(&4, |&(k, _)| k), Err(2));
+        assert_eq!(deque.binary_search_by_key(&6, |&(k, _)| k), Err(3));
+    }
+
+    #[test]
+    fn test_binary_search_by_key_string_key() {
+        let deque: Deque<(String, i32)> = (
+            vec![
+                ("apple".to_string(), 1),
+                ("banana".to_string(), 2),
+                ("cherry".to_string(), 3),
+            ],
+            10,
+        )
+            .into();
+        assert_eq!(
+            deque.binary_search_by_key(&"banana".to_string(), |(k, _)| k.clone()),
+            Ok(1)
+        );
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_retain_then_extend() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 5).into();
+        deque.retain(|&x| x % 2 == 0);
+        assert_eq!(deque.len(), 2);
+        deque.extend([6, 7, 8]);
+        assert_eq!(deque.len(), 5);
+        assert_eq!(deque.front(), Some(&2));
+    }
+
+    #[test]
+    fn test_drain_then_push() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 5).into();
+        let _ = deque.drain(..3);
+        assert_eq!(deque.len(), 2);
+        deque.push_back(6);
+        deque.push_back(7);
+        assert_eq!(deque.len(), 4);
+        assert_eq!(deque.front(), Some(&4));
+    }
+
+    #[test]
+    fn test_rotate_then_binary_search() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        // After rotate_left(2): [3, 4, 5, 1, 2] - not sorted!
+        // This shows that binary_search requires sorted data
+        deque.rotate_left(2);
+        // The deque is now [3, 4, 5, 1, 2] which is not sorted
+        // binary_search on unsorted data gives undefined but safe results
+        let _ = deque.binary_search(&3); // May not find it correctly
+    }
+
+    #[test]
+    fn test_swap_and_remove() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        deque.swap(0, 4);
+        assert_eq!(deque.remove(0), Some(5));
+        assert_eq!(deque.len(), 4);
+        assert_eq!(deque.front(), Some(&2));
+    }
+
+    #[test]
+    fn test_truncate_and_remaining_capacity() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        assert_eq!(deque.remaining_capacity(), 5);
+        deque.truncate(2);
+        assert_eq!(deque.remaining_capacity(), 8);
+    }
+
+    #[test]
+    fn test_is_full_after_retain() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 5).into();
+        assert!(deque.is_full());
+        deque.retain(|&x| x > 3);
+        assert!(!deque.is_full());
+        assert_eq!(deque.remaining_capacity(), 3);
+    }
+}
+
+#[cfg(test)]
+mod count_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_count_multiple_occurrences() {
+        let deque: Deque<i32> = (vec![1, 2, 2, 3, 2, 4], 10).into();
+        assert_eq!(deque.count(&2), 3);
+    }
+
+    #[test]
+    fn test_count_single_occurrence() {
+        let deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        assert_eq!(deque.count(&3), 1);
+    }
+
+    #[test]
+    fn test_count_no_occurrences() {
+        let deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        assert_eq!(deque.count(&10), 0);
+    }
+
+    #[test]
+    fn test_count_empty_deque() {
+        let deque: Deque<i32> = Deque::new(5);
+        assert_eq!(deque.count(&1), 0);
+    }
+
+    #[test]
+    fn test_count_all_same() {
+        let deque: Deque<i32> = (vec![7, 7, 7, 7, 7], 10).into();
+        assert_eq!(deque.count(&7), 5);
+    }
+
+    #[test]
+    fn test_count_strings() {
+        let deque: Deque<&str> = (vec!["a", "b", "a", "c", "a"], 10).into();
+        assert_eq!(deque.count(&"a"), 3);
+        assert_eq!(deque.count(&"b"), 1);
+        assert_eq!(deque.count(&"d"), 0);
+    }
+}
+
+#[cfg(test)]
+mod index_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_index_found_first() {
+        let deque: Deque<i32> = (vec![1, 2, 3, 2, 4], 10).into();
+        assert_eq!(deque.index(&2), Some(1));
+    }
+
+    #[test]
+    fn test_index_found_at_start() {
+        let deque: Deque<i32> = (vec![5, 2, 3, 4], 10).into();
+        assert_eq!(deque.index(&5), Some(0));
+    }
+
+    #[test]
+    fn test_index_found_at_end() {
+        let deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        assert_eq!(deque.index(&5), Some(4));
+    }
+
+    #[test]
+    fn test_index_not_found() {
+        let deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        assert_eq!(deque.index(&10), None);
+    }
+
+    #[test]
+    fn test_index_empty_deque() {
+        let deque: Deque<i32> = Deque::new(5);
+        assert_eq!(deque.index(&1), None);
+    }
+
+    #[test]
+    fn test_index_range_basic() {
+        let deque: Deque<i32> = (vec![1, 2, 3, 2, 4], 10).into();
+        assert_eq!(deque.index_range(&2, 0, 5), Some(1));
+        assert_eq!(deque.index_range(&2, 2, 5), Some(3));
+    }
+
+    #[test]
+    fn test_index_range_not_in_range() {
+        let deque: Deque<i32> = (vec![1, 2, 3, 2, 4], 10).into();
+        assert_eq!(deque.index_range(&2, 4, 5), None);
+    }
+
+    #[test]
+    fn test_index_range_invalid_range() {
+        let deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        assert_eq!(deque.index_range(&2, 5, 3), None); // start > end
+    }
+
+    #[test]
+    fn test_index_range_end_beyond_len() {
+        let deque: Deque<i32> = (vec![1, 2, 3], 10).into();
+        assert_eq!(deque.index_range(&3, 0, 100), Some(2));
+    }
+}
+
+#[cfg(test)]
+mod extend_front_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_extend_front_basic() {
+        let mut deque: Deque<i32> = (vec![4, 5], 10).into();
+        deque.extend_front([1, 2, 3]);
+        // Elements prepended in reverse: 3, 2, 1, 4, 5
+        assert_eq!(deque.len(), 5);
+        assert_eq!(deque.get(0), Some(&3));
+        assert_eq!(deque.get(1), Some(&2));
+        assert_eq!(deque.get(2), Some(&1));
+        assert_eq!(deque.get(3), Some(&4));
+        assert_eq!(deque.get(4), Some(&5));
+    }
+
+    #[test]
+    fn test_extend_front_empty_deque() {
+        let mut deque: Deque<i32> = Deque::new(10);
+        deque.extend_front([1, 2, 3]);
+        assert_eq!(deque.len(), 3);
+        assert_eq!(deque.get(0), Some(&3));
+        assert_eq!(deque.get(1), Some(&2));
+        assert_eq!(deque.get(2), Some(&1));
+    }
+
+    #[test]
+    fn test_extend_front_respects_maxlen() {
+        let mut deque: Deque<i32> = (vec![4, 5], 4).into();
+        deque.extend_front([1, 2, 3]);
+        // maxlen is 4, so oldest elements (from back) are dropped
+        assert_eq!(deque.len(), 4);
+        assert_eq!(deque.get(0), Some(&3));
+        assert_eq!(deque.get(1), Some(&2));
+        assert_eq!(deque.get(2), Some(&1));
+        assert_eq!(deque.get(3), Some(&4));
+    }
+
+    #[test]
+    fn test_extend_front_empty_iterator() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 10).into();
+        deque.extend_front(std::iter::empty());
+        assert_eq!(deque.len(), 3);
+    }
+
+    #[test]
+    fn test_extend_front_maxlen_one() {
+        let mut deque: Deque<i32> = Deque::new(1);
+        deque.extend_front([1, 2, 3]);
+        assert_eq!(deque.len(), 1);
+        assert_eq!(deque.front(), Some(&3));
+    }
+}
+
+#[cfg(test)]
+mod reverse_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_reverse_basic() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        deque.reverse();
+        assert_eq!(deque.get(0), Some(&5));
+        assert_eq!(deque.get(1), Some(&4));
+        assert_eq!(deque.get(2), Some(&3));
+        assert_eq!(deque.get(3), Some(&2));
+        assert_eq!(deque.get(4), Some(&1));
+    }
+
+    #[test]
+    fn test_reverse_two_elements() {
+        let mut deque: Deque<i32> = (vec![1, 2], 10).into();
+        deque.reverse();
+        assert_eq!(deque.get(0), Some(&2));
+        assert_eq!(deque.get(1), Some(&1));
+    }
+
+    #[test]
+    fn test_reverse_single_element() {
+        let mut deque: Deque<i32> = (vec![42], 10).into();
+        deque.reverse();
+        assert_eq!(deque.get(0), Some(&42));
+    }
+
+    #[test]
+    fn test_reverse_empty() {
+        let mut deque: Deque<i32> = Deque::new(10);
+        deque.reverse(); // Should not panic
+        assert!(deque.is_empty());
+    }
+
+    #[test]
+    fn test_reverse_twice() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        deque.reverse();
+        deque.reverse();
+        assert_eq!(deque.get(0), Some(&1));
+        assert_eq!(deque.get(4), Some(&5));
+    }
+
+    #[test]
+    fn test_reverse_strings() {
+        let mut deque: Deque<&str> = (vec!["a", "b", "c"], 10).into();
+        deque.reverse();
+        assert_eq!(deque.get(0), Some(&"c"));
+        assert_eq!(deque.get(1), Some(&"b"));
+        assert_eq!(deque.get(2), Some(&"a"));
+    }
+}
+
+#[cfg(test)]
+mod remove_first_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_remove_first_found() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 2, 4], 10).into();
+        assert_eq!(deque.remove_first(&2), Some(2));
+        assert_eq!(deque.len(), 4);
+        assert_eq!(deque.get(0), Some(&1));
+        assert_eq!(deque.get(1), Some(&3));
+        assert_eq!(deque.get(2), Some(&2)); // Second 2 still there
+        assert_eq!(deque.get(3), Some(&4));
+    }
+
+    #[test]
+    fn test_remove_first_not_found() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3, 4, 5], 10).into();
+        assert_eq!(deque.remove_first(&10), None);
+        assert_eq!(deque.len(), 5);
+    }
+
+    #[test]
+    fn test_remove_first_from_front() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 10).into();
+        assert_eq!(deque.remove_first(&1), Some(1));
+        assert_eq!(deque.len(), 2);
+        assert_eq!(deque.front(), Some(&2));
+    }
+
+    #[test]
+    fn test_remove_first_from_back() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 10).into();
+        assert_eq!(deque.remove_first(&3), Some(3));
+        assert_eq!(deque.len(), 2);
+        assert_eq!(deque.back(), Some(&2));
+    }
+
+    #[test]
+    fn test_remove_first_only_element() {
+        let mut deque: Deque<i32> = (vec![42], 10).into();
+        assert_eq!(deque.remove_first(&42), Some(42));
+        assert!(deque.is_empty());
+    }
+
+    #[test]
+    fn test_remove_first_empty_deque() {
+        let mut deque: Deque<i32> = Deque::new(10);
+        assert_eq!(deque.remove_first(&1), None);
+    }
+
+    #[test]
+    fn test_remove_first_all_same() {
+        let mut deque: Deque<i32> = (vec![5, 5, 5, 5], 10).into();
+        assert_eq!(deque.remove_first(&5), Some(5));
+        assert_eq!(deque.len(), 3);
+        assert_eq!(deque.count(&5), 3);
+    }
+}
+
+#[cfg(test)]
+mod insert_tests {
+    use super::Deque;
+
+    #[test]
+    fn test_insert_middle() {
+        let mut deque: Deque<i32> = (vec![1, 3, 4], 5).into();
+        assert_eq!(deque.insert(1, 2), None);
+        assert_eq!(deque.len(), 4);
+        assert_eq!(deque.get(0), Some(&1));
+        assert_eq!(deque.get(1), Some(&2));
+        assert_eq!(deque.get(2), Some(&3));
+        assert_eq!(deque.get(3), Some(&4));
+    }
+
+    #[test]
+    fn test_insert_at_front() {
+        let mut deque: Deque<i32> = (vec![2, 3, 4], 5).into();
+        assert_eq!(deque.insert(0, 1), None);
+        assert_eq!(deque.front(), Some(&1));
+        assert_eq!(deque.len(), 4);
+    }
+
+    #[test]
+    fn test_insert_at_back() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        assert_eq!(deque.insert(3, 4), None);
+        assert_eq!(deque.back(), Some(&4));
+        assert_eq!(deque.len(), 4);
+    }
+
+    #[test]
+    fn test_insert_into_empty() {
+        let mut deque: Deque<i32> = Deque::new(5);
+        assert_eq!(deque.insert(0, 1), None);
+        assert_eq!(deque.len(), 1);
+        assert_eq!(deque.front(), Some(&1));
+    }
+
+    #[test]
+    fn test_insert_full_deque_drops_back() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 3).into();
+        let dropped = deque.insert(1, 10);
+        assert_eq!(dropped, Some(3)); // 3 was at the back and got dropped
+        assert_eq!(deque.len(), 3);
+        assert_eq!(deque.iter().copied().collect::<Vec<_>>(), vec![1, 10, 2]);
+    }
+
+    #[test]
+    fn test_insert_full_deque_at_front() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 3).into();
+        let dropped = deque.insert(0, 0);
+        assert_eq!(dropped, Some(3));
+        assert_eq!(deque.iter().copied().collect::<Vec<_>>(), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_insert_full_deque_at_back() {
+        // Inserting at the back of a full deque: we pop_back first, then insert.
+        // So [1,2,3] -> pop_back -> [1,2] (len=2) -> insert(2, 10) -> [1,2,10]
+        // Note: after popping, len is 2, so we can only insert at index 0, 1, or 2
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 3).into();
+        let dropped = deque.insert(2, 10); // Insert at the new back position
+        assert_eq!(dropped, Some(3));
+        assert_eq!(deque.iter().copied().collect::<Vec<_>>(), vec![1, 2, 10]);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of bounds")]
+    fn test_insert_index_out_of_bounds() {
+        let mut deque: Deque<i32> = (vec![1, 2, 3], 5).into();
+        deque.insert(10, 4);
+    }
+
+    #[test]
+    fn test_insert_fills_to_maxlen() {
+        let mut deque: Deque<i32> = (vec![1, 2, 4], 4).into();
+        assert_eq!(deque.insert(2, 3), None);
+        assert_eq!(deque.len(), 4);
+        assert!(deque.is_full());
+        assert_eq!(deque.get(2), Some(&3));
+    }
+}
+
 #[cfg(feature = "serde")]
 #[cfg(test)]
 mod serde_tests {
@@ -1455,5 +3167,27 @@ mod serde_tests {
         assert_eq!(deserialized.get(0), Some(&10));
         assert_eq!(deserialized.get(1), Some(&20));
         assert_eq!(deserialized.get(2), Some(&30));
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T: Serialize> Serialize for Deque<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.deque.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Deque<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let deque = VecDeque::deserialize(deserializer)?;
+        let maxlen = deque.len();
+        Ok(Self { deque, maxlen })
     }
 }


### PR DESCRIPTION
## Added Methods

This PR adds new methods to bring `FixedDeque` closer to feature parity with Rust's `VecDeque` and Python's `collections.deque`.

### From Rust's `VecDeque`

- `is_full()` - check if deque has reached maxlen
- `remaining_capacity()` - space left before full
- `swap(i, j)` - swap elements at two indices
- `truncate(len)` - shorten deque to given length
- `remove(index)` - remove and return element at index
- `retain(f)` / `retain_mut(f)` - keep only elements matching predicate
- `drain(range)` - remove and iterate over a range
- `rotate_left(n)` / `rotate_right(n)` - rotate elements
- `as_slices()` / `as_mut_slices()` - view as slice pair
- `make_contiguous()` - rearrange to single contiguous slice
- `binary_search()` / `binary_search_by()` / `binary_search_by_key()` - binary search on sorted deque

### From Python's `collections.deque`

- `count(value)` - count occurrences of a value
- `index(value)` - find index of first occurrence
- `index_range(value, start, end)` - find index within range
- `extend_front(iter)` - extend from front (Python's `extendleft`)
- `reverse()` - reverse in place
- `remove_first(value)` - remove first occurrence of value
- `insert(index, value)` - insert at index, drops back element if full